### PR TITLE
Fix invalid target type when target entity and member entity are of different type

### DIFF
--- a/og_ui/og_ui.module
+++ b/og_ui/og_ui.module
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\BundleEntityFormBase;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\og\Og;
 use Drupal\og\OgGroupAudienceHelper;
 use Drupal\og_ui\BundleFormAlter;
@@ -75,18 +76,20 @@ function og_ui_entity_type_save(EntityInterface $entity) {
   }
 
   // Change the field target type and bundle.
+  if ($field_storage = FieldStorageConfig::loadByName($entity_type_id, OgGroupAudienceHelper::DEFAULT_FIELD)) {
+    $target_type = $field_storage->getSetting('target_type');
+    if ($entity->og_target_type !== $target_type) {
+      // @todo It's probably not possible to change the field storage after the
+      //   field has data. We should disable this option in the UI.
+      $field_storage->setSetting('target_type', $entity->og_target_type);
+      $field_storage->save();
+    }
+  }
   if ($field = FieldConfig::loadByName($entity_type_id, $bundle, OgGroupAudienceHelper::DEFAULT_FIELD)) {
     $handler_settings = $field->getSetting('handler_settings');
-    $save = FALSE;
-    foreach (['target_type', 'target_bundles'] as $key) {
-      $entity_key = 'og_' . $key;
-      if (!isset($handler_settings[$key]) || $entity->$entity_key != $handler_settings[$key]) {
-        $handler_settings[$key] = $entity->$entity_key;
-        $field->setSetting('handler_settings', $handler_settings);
-        $save = TRUE;
-      }
-    }
-    if ($save) {
+    if (!isset($handler_settings['target_bundles']) || $entity->og_target_bundles != $handler_settings['target_bundles']) {
+      $handler_settings['target_bundles'] = $entity->og_target_bundles;
+      $field->setSetting('handler_settings', $handler_settings);
       $field->save();
     }
   }

--- a/src/Plugin/Field/FieldWidget/OgComplex.php
+++ b/src/Plugin/Field/FieldWidget/OgComplex.php
@@ -286,7 +286,7 @@ class OgComplex extends EntityReferenceAutocompleteWidget {
       'target_id' => [
         // @todo Allow this to be configurable with a widget setting.
         '#type' => 'entity_autocomplete',
-        '#target_type' => $this->fieldDefinition->getTargetEntityTypeId(),
+        '#target_type' => $this->getFieldSetting('target_type'),
         '#selection_handler' => 'og:default',
         '#selection_settings' => [
           'other_groups' => TRUE,

--- a/src/Plugin/Field/FieldWidget/OgComplex.php
+++ b/src/Plugin/Field/FieldWidget/OgComplex.php
@@ -74,7 +74,7 @@ class OgComplex extends EntityReferenceAutocompleteWidget {
     $cardinality = $this->fieldDefinition->getFieldStorageDefinition()->getCardinality();
     $parents = $form['#parents'];
 
-    $target_type = $this->fieldDefinition->getTargetEntityTypeId();
+    $target_type = $this->getFieldSetting('handler_settings')['target_type'];
     $user_groups = Og::getEntityGroups(User::load(\Drupal::currentUser()->id()));
     $user_groups_target_type = isset($user_groups[$target_type]) ? $user_groups[$target_type] : [];
     $user_group_ids = array_map(function($group) {
@@ -229,7 +229,7 @@ class OgComplex extends EntityReferenceAutocompleteWidget {
 
     $delta = 0;
 
-    $target_type = $this->fieldDefinition->getTargetEntityTypeId();
+    $target_type = $this->getFieldSetting('handler_settings')['target_type'];
 
     $user_groups = Og::getEntityGroups(User::load(\Drupal::currentUser()->id()));
     $user_groups_target_type = isset($user_groups[$target_type]) ? $user_groups[$target_type] : [];
@@ -286,7 +286,7 @@ class OgComplex extends EntityReferenceAutocompleteWidget {
       'target_id' => [
         // @todo Allow this to be configurable with a widget setting.
         '#type' => 'entity_autocomplete',
-        '#target_type' => $this->getFieldSetting('target_type'),
+        '#target_type' => $this->getFieldSetting('handler_settings')['target_type'],
         '#selection_handler' => 'og:default',
         '#selection_settings' => [
           'other_groups' => TRUE,

--- a/src/Plugin/Field/FieldWidget/OgComplex.php
+++ b/src/Plugin/Field/FieldWidget/OgComplex.php
@@ -74,7 +74,7 @@ class OgComplex extends EntityReferenceAutocompleteWidget {
     $cardinality = $this->fieldDefinition->getFieldStorageDefinition()->getCardinality();
     $parents = $form['#parents'];
 
-    $target_type = $this->getFieldSetting('handler_settings')['target_type'];
+    $target_type = $this->fieldDefinition->getFieldStorageDefinition()->getSetting('target_type');
     $user_groups = Og::getEntityGroups(User::load(\Drupal::currentUser()->id()));
     $user_groups_target_type = isset($user_groups[$target_type]) ? $user_groups[$target_type] : [];
     $user_group_ids = array_map(function($group) {
@@ -229,7 +229,7 @@ class OgComplex extends EntityReferenceAutocompleteWidget {
 
     $delta = 0;
 
-    $target_type = $this->getFieldSetting('handler_settings')['target_type'];
+    $target_type = $this->fieldDefinition->getFieldStorageDefinition()->getSetting('target_type');
 
     $user_groups = Og::getEntityGroups(User::load(\Drupal::currentUser()->id()));
     $user_groups_target_type = isset($user_groups[$target_type]) ? $user_groups[$target_type] : [];
@@ -286,7 +286,7 @@ class OgComplex extends EntityReferenceAutocompleteWidget {
       'target_id' => [
         // @todo Allow this to be configurable with a widget setting.
         '#type' => 'entity_autocomplete',
-        '#target_type' => $this->getFieldSetting('handler_settings')['target_type'],
+        '#target_type' => $this->fieldDefinition->getFieldStorageDefinition()->getSetting('target_type'),
         '#selection_handler' => 'og:default',
         '#selection_settings' => [
           'other_groups' => TRUE,

--- a/src/Plugin/OgFields/AudienceField.php
+++ b/src/Plugin/OgFields/AudienceField.php
@@ -32,11 +32,6 @@ class AudienceField extends OgFieldBase implements OgFieldsInterface {
       'cardinality' => FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED,
       'custom_storage' => $this->getEntityType() == 'user',
       'settings' => [
-        'handler' => 'og',
-        'handler_settings' => [
-          'target_bundles' => [],
-          'membership_type' => OgMembershipInterface::TYPE_DEFAULT,
-        ],
         'target_type' => $this->getEntityType(),
       ],
       'type' => $this->getEntityType() == 'user' ? 'og_membership_reference' : 'og_standard_reference',
@@ -53,6 +48,10 @@ class AudienceField extends OgFieldBase implements OgFieldsInterface {
       'description' => $this->t('OG group audience reference field.'),
       'display_label' => TRUE,
       'label' => $this->t('Groups audience'),
+      'settings' => [
+        'handler' => 'og',
+        'handler_settings' => [],
+      ],
     ];
 
     return parent::getFieldConfigBaseDefinition($values);

--- a/tests/src/Functional/OgComplexWidgetTest.php
+++ b/tests/src/Functional/OgComplexWidgetTest.php
@@ -46,11 +46,9 @@ class OgComplexWidgetTest extends BrowserTestBase {
     // group content type.
     $this->createContentType(['type' => 'post']);
     $settings = [
-      'field_config' => [
+      'field_storage_config' => [
         'settings' => [
-          'handler_settings' => [
-            'target_type' => 'node',
-          ],
+          'target_type' => 'node',
         ],
       ],
     ];

--- a/tests/src/Functional/OgComplexWidgetTest.php
+++ b/tests/src/Functional/OgComplexWidgetTest.php
@@ -7,6 +7,8 @@
 
 namespace Drupal\Tests\og\Functional;
 
+use Drupal\block_content\Entity\BlockContent;
+use Drupal\block_content\Entity\BlockContentType;
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
@@ -30,7 +32,7 @@ class OgComplexWidgetTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['node', 'og'];
+  public static $modules = ['block_content', 'node', 'og'];
 
   /**
    * {@inheritdoc}
@@ -38,9 +40,11 @@ class OgComplexWidgetTest extends BrowserTestBase {
   function setUp() {
     parent::setUp();
 
-    // Create a "group" node type and turn it into a group type.
-    $this->createContentType(['type' => 'group']);
-    Og::groupManager()->addGroup('node', 'group');
+    // Create a "group" bundle on the Custom Block entity type and turn it into
+    // a group. Note we're not using the Entity Test entity for this since it
+    // does not have real support for multiple bundles.
+    BlockContentType::create(['type' => 'group']);
+    Og::groupManager()->addGroup('block_content', 'group');
 
     // Add a group audience field to the "post" node type, turning it into a
     // group content type.
@@ -48,7 +52,7 @@ class OgComplexWidgetTest extends BrowserTestBase {
     $settings = [
       'field_storage_config' => [
         'settings' => [
-          'target_type' => 'node',
+          'target_type' => 'block_content',
         ],
       ],
     ];
@@ -63,11 +67,12 @@ class OgComplexWidgetTest extends BrowserTestBase {
     $group_owner = $this->drupalCreateUser(['access content', 'create post content']);
 
     // Create a group content type owned by the group owner.
-    $settings = [
+    $values = [
       'type' => 'group',
       'uid' => $group_owner->id(),
     ];
-    $group = $this->createNode($settings);
+    $group = BlockContent::create($values);
+    $group->save();
 
     // Log in as administrator.
     $this->drupalLogin($admin_user);

--- a/tests/src/Functional/OgComplexWidgetTest.php
+++ b/tests/src/Functional/OgComplexWidgetTest.php
@@ -45,7 +45,16 @@ class OgComplexWidgetTest extends BrowserTestBase {
     // Add a group audience field to the "post" node type, turning it into a
     // group content type.
     $this->createContentType(['type' => 'post']);
-    Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'node', 'post');
+    $settings = [
+      'field_config' => [
+        'settings' => [
+          'handler_settings' => [
+            'target_type' => 'node',
+          ],
+        ],
+      ],
+    ];
+    Og::createField(OgGroupAudienceHelper::DEFAULT_FIELD, 'node', 'post', $settings);
   }
 
   /**

--- a/tests/src/Functional/OgComplexWidgetTest.php
+++ b/tests/src/Functional/OgComplexWidgetTest.php
@@ -60,9 +60,11 @@ class OgComplexWidgetTest extends BrowserTestBase {
   }
 
   /**
-   * Tests the "Other Groups" field.
+   * Tests adding groups with the "Groups audience" and "Other Groups" fields.
+   *
+   * @dataProvider ogComplexFieldsProvider
    */
-  function testOtherGroups() {
+  function testFields($field, $field_name) {
     $admin_user = $this->drupalCreateUser(['administer group', 'access content', 'create post content']);
     $group_owner = $this->drupalCreateUser(['access content', 'create post content']);
 
@@ -77,11 +79,10 @@ class OgComplexWidgetTest extends BrowserTestBase {
     // Log in as administrator.
     $this->drupalLogin($admin_user);
 
-    // Create a new post in the group by using the "Other Groups" field in the
-    // UI.
+    // Create a new post in the group by using the given field in the UI.
     $edit = [
       'title[0][value]' => "Group owner's post.",
-      'other_groups[0][target_id]' => "group ({$group->id()})",
+      $field_name => "group ({$group->id()})",
     ];
     $this->drupalGet('node/add/post');
     $this->submitForm($edit, 'Save');
@@ -103,8 +104,20 @@ class OgComplexWidgetTest extends BrowserTestBase {
     // Check that the post references the group correctly.
     /** @var OgMembershipReferenceItemList $reference_list */
     $reference_list = $post->get(OgGroupAudienceHelper::DEFAULT_FIELD);
-    $this->assertEquals(1, $reference_list->count(), 'There is 1 reference after adding a group to the "Other Groups" field.');
-    $this->assertEquals($group->id(), $reference_list->first()->getValue()['target_id'], 'The "Other Groups" field references the correct group.');
+    $this->assertEquals(1, $reference_list->count(), "There is 1 reference after adding a group to the '$field' field.");
+    $this->assertEquals($group->id(), $reference_list->first()->getValue()['target_id'], "The '$field' field references the correct group.");
+  }
+
+  /**
+   * Data provider for ::testFields()
+   *
+   * @return array
+   */
+  public function ogComplexFieldsProvider() {
+    return [
+      ['Groups audience', 'og_group_ref[0][target_id]'],
+      ['Other groups', 'other_groups[0][target_id]'],
+    ];
   }
 
 }


### PR DESCRIPTION
$this->fieldDefinition->getTargetEntityTypeId() returns the type of the entity that the field is attached to.

This is a logical mistake. Target type should be the group type.
Changed to $this->getFieldSetting('target_type') in order to obtaing the target type of the original widget field.
Similar to: https://github.com/amitaibu/og/issues/120
